### PR TITLE
Cleaned Up the UI

### DIFF
--- a/app/components/mute-control.js
+++ b/app/components/mute-control.js
@@ -4,7 +4,7 @@ import layout from '../templates/components/mute-control';
 export default Ember.Component.extend({
   layout: layout,
   tagName: "button",
-  classNames: ["btn", "btn-default", "navbar-btn", "navbar-right"],
+  classNames: ["btn", "btn-default"],
   classNameBindings: ["isMuted:active"],
   attributeBindings: ["title"],
 

--- a/app/components/playback-control.js
+++ b/app/components/playback-control.js
@@ -3,7 +3,6 @@ import layout from '../templates/components/playback-control';
 
 export default Ember.Component.extend({
   layout: layout,
-  classNames: ["nav", "navbar-nav", "navbar-right"],
 
   setup: function () {
     this.get("mop").state().then( (state) => {

--- a/app/components/playback-control.js
+++ b/app/components/playback-control.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/playback-control';
 
 export default Ember.Component.extend({
   layout: layout,
+  classNames: ['playback-control'],
 
   setup: function () {
     this.get("mop").state().then( (state) => {

--- a/app/components/slider-control.js
+++ b/app/components/slider-control.js
@@ -1,0 +1,57 @@
+import Ember from 'ember';
+import layout from '../templates/components/slider-control';
+
+export default Ember.Component.extend({
+  layout: layout,
+  classNames: ['slider-control'],
+  percentage: 0,
+
+  setupExternalListeners: function() {
+    function resize (that) {
+      that.set("width", that.element.clientWidth);
+    }
+
+    $(window).on("resize", () => resize(this));
+    resize(this);
+
+    $(window).on("mousemove", (e) => { this.mousemove(e, this); });
+    $(window).on("mouseup", (e) => { this.mouseup(e, this); });
+  }.on('didInsertElement'),
+
+  teardownExternalListeners: function() {
+    $(window).off("resize");
+    $(window).off("mousemove");
+    $(window).off("mouseup");
+  }.on('willDestroyElement'),
+
+  // Default Ember Events
+  mouseDown: function(e) {
+    this.sendAction('pre');
+    this.set("isMouseDown", true);
+    e.preventDefault();
+  },
+
+  // Custom events so we get all moves
+  mouseup: function(e, that) {
+    if (that.get("isMouseDown")) {
+      that.setPercentage(e, this);
+      that.sendAction('post');
+    }
+
+    that.set("isMouseDown", false);
+    e.preventDefault();
+  },
+  mousemove: function(e, that) {
+    if (that.get("isMouseDown")) {
+      that.setPercentage(e, that);
+    }
+  },
+
+  setPercentage: function(e, that) {
+    var percentage = Math.round(((e.pageX - $(that.element).offset().left) / that.get("width")) * 100);
+    var clamped = Math.max(0, Math.min(percentage, 100))
+    that.set("percentage", clamped);
+    e.preventDefault();
+  },
+});
+

--- a/app/components/slider-control.js
+++ b/app/components/slider-control.js
@@ -26,9 +26,11 @@ export default Ember.Component.extend({
 
   // Default Ember Events
   mouseDown: function(e) {
-    this.sendAction('pre');
-    this.set("isMouseDown", true);
-    e.preventDefault();
+    if (e.which === 1) {
+      this.sendAction('pre');
+      this.set("isMouseDown", true);
+      e.preventDefault();
+    }
   },
 
   // Custom events so we get all moves

--- a/app/components/slider-control.js
+++ b/app/components/slider-control.js
@@ -4,6 +4,7 @@ import layout from '../templates/components/slider-control';
 export default Ember.Component.extend({
   layout: layout,
   classNames: ['slider-control'],
+  classNameBindings: ['isMouseDown:dragging'],
   percentage: 0,
 
   setupExternalListeners: function() {

--- a/app/components/track-progress.js
+++ b/app/components/track-progress.js
@@ -3,7 +3,7 @@ import layout from '../templates/components/track-progress';
 
 export default Ember.Component.extend({
   layout: layout,
-
+  classNames: ['clearfix'],
   setup: function () {
     var that = this,
         mop = this.get("mop"),
@@ -11,15 +11,17 @@ export default Ember.Component.extend({
 
     timer = new ProgressTimer({
       callback: function (position, duration) {
-        that.set("progress", position / duration * 100);
+        that.set("percentage", position / duration * 100);
+        that.set("currentTime", position)
       },
+
       // Target milliseconds between callbacks, default: 100, min: 10.
       updateRate: 1000,
+
       // Force the use of the legacy setTimeout fallback, default: false.
       // Fixes issue with getting out of sync on inactive tab
       disableRequestAnimationFrame: true
     });
-
     this.set("timer", timer);
 
     // TODO: simplify
@@ -72,10 +74,25 @@ export default Ember.Component.extend({
     return this.get("currentTrack.track.length");
   }.property("currentTrack"),
 
-  mouseUp: function () {
-    if (!this.get("isDisabled")) {
-      var timePosition = Math.round(this.get("progress") * this.get("duration") / 100);
-      this.get("mop").seek(timePosition);
+  actions: {
+    post: function () {
+      if (!this.get("isDisabled")) {
+        var timePosition = Math.round(this.get("percentage") * this.get("duration") / 100);
+        this.get("mop").seek(timePosition);
+
+        if (this.get("wasRunning"))
+          this.get("timer").start()
+      }
+    },
+
+    pre: function() {
+      var timer = this.get("timer")
+      if (timer._running)
+        this.set("wasRunning", true)
+      else
+        this.set("wasRunning", false)
+
+      timer.stop()
     }
   }
 });

--- a/app/components/track-progress.js
+++ b/app/components/track-progress.js
@@ -3,7 +3,6 @@ import layout from '../templates/components/track-progress';
 
 export default Ember.Component.extend({
   layout: layout,
-  classNames: ["nav", "navbar-nav", "navbar-right", "navbar-form"],
 
   setup: function () {
     var that = this,

--- a/app/components/volume-control.js
+++ b/app/components/volume-control.js
@@ -3,18 +3,21 @@ import layout from '../templates/components/volume-control';
 
 export default Ember.Component.extend({
   layout: layout,
-
+  classNames: ['volume-control'],
   setup: function () {
     this.get("mop").getVolume().then( (volume) => {
-      this.set("volume", volume);
+      this.set("percentage", volume);
     });
 
     this.get("mop.client").on("event:volumeChanged", (changes) => {
-      this.set("volume", changes.volume);
+      this.set("percentage", changes.volume);
     });
   }.on("init"),
 
-  mouseUp: function () {
-    this.get("mop").setVolume(this.get("volume"));
-  }
+  actions: {
+    post: function () {
+      this.get("mop").setVolume(this.get("percentage"));
+    }
+  },
 });
+

--- a/app/components/volume-control.js
+++ b/app/components/volume-control.js
@@ -3,7 +3,6 @@ import layout from '../templates/components/volume-control';
 
 export default Ember.Component.extend({
   layout: layout,
-  classNames: ["nav", "navbar-nav", "navbar-right", "navbar-form"],
 
   setup: function () {
     this.get("mop").getVolume().then( (volume) => {

--- a/app/helpers/to-time.js
+++ b/app/helpers/to-time.js
@@ -1,0 +1,11 @@
+import Ember from "ember";
+
+export default Ember.Helper.extend({
+  compute: function(params) {
+    var time = params[0];
+    var minutes = Math.floor(time / 60000);
+    var seconds = ((time % 60000) / 1000).toFixed(0);
+    return minutes + ":" + (seconds < 10 ? '0' : '') + seconds;
+  }
+});
+

--- a/app/index.html
+++ b/app/index.html
@@ -19,13 +19,6 @@
     {{content-for 'body'}}
     <main id="app" class="site-content"></main>
 
-    <footer class="footer">
-      {{content-for 'body-footer'}}
-      <div class="container">
-        <div class="footer-item text-muted">Source available on <a href="https://github.com/cowbell/mopster">GitHub</a></div>
-      </div>
-    </footer>
-
     <script src="assets/vendor.js"></script>
     <script src="assets/mopster.js"></script>
   </body>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -29,10 +29,11 @@ header > div > button {
 
 .volume-control {
   display: flex;
+  justify-content: flex-end;
 }
 
 .volume-control > .slider-control {
-  width: 100%;
+  width: 50%;
 }
 
 .volume-control > button {
@@ -42,6 +43,14 @@ header > div > button {
 .playback-controls {
   display: flex;
   justify-content: space-between;
+}
+
+.playback-controls > div {
+  flex: 1;
+}
+
+.playback-controls > .playback-control {
+  text-align: center;
 }
 
 .playback-controls > .volume-control {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -72,6 +72,11 @@ header > div > button {
   position: absolute;
   height: 100%;
   background-color: #e5e5e5;
+  transition: width 0.1s;
+}
+
+.slider-control > div:hover > .handle, .slider-control.dragging .handle {
+  transform: scale(1);
 }
 
 .slider-control > div > .handle {
@@ -80,6 +85,8 @@ header > div > button {
   top: -0.25em;
   width: 0.5em;
   background-color: #008CBA;
+  transform: scaleX(0.1) scaleY(calc(1 / 1.5));
+  transition: transform 0.1s, left 0.1s;
 }
 
 .default-cursor {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -27,6 +27,52 @@ header > div > button {
   margin-bottom: 8px;
 }
 
+.volume-control {
+  display: flex;
+}
+
+.volume-control > .slider-control {
+  width: 100%;
+}
+
+.volume-control > button {
+  margin-right: 0.5em;
+}
+
+.playback-controls {
+  display: flex;
+  justify-content: space-between;
+}
+
+.playback-controls > .volume-control {
+  width: 50%;
+}
+
+.slider-control {
+  margin: 0.5em 0;
+}
+
+.slider-control > div {
+  height: 1em;
+  position: relative;
+  background: #FAFAFA;
+  margin: 0.25em 0;
+}
+
+.slider-control > div > .active-segment {
+  position: absolute;
+  height: 100%;
+  background-color: #e5e5e5;
+}
+
+.slider-control > div > .handle {
+  position: absolute;
+  height: 1.5em;
+  top: -0.25em;
+  width: 0.5em;
+  background-color: #008CBA;
+}
+
 .default-cursor {
   cursor: default;
 }
@@ -58,18 +104,22 @@ header > div > button {
   stroke-width: 5;
 }
 
-.site {
+main#app > div.ember-view {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
 }
 
-.site-content {
+main#app > div.ember-view > .container {
   flex: 1;
 }
 
 .footer {
   background-color: #f5f5f5;
+}
+
+footer.footer > .container {
+  margin: 0.75em auto;
 }
 
 .footer-item {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -120,14 +120,8 @@ header > div > button {
   stroke-width: 5;
 }
 
-main#app > div.ember-view {
-  display: flex;
-  min-height: 100vh;
-  flex-direction: column;
-}
-
 main#app > div.ember-view > .container {
-  flex: 1;
+  margin-bottom: 10em;
 }
 
 .footer {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -38,6 +38,7 @@
   {{outlet}}
 </div>
 
+{{#unless bare}}
 <footer class="footer">
   <div class="container">
     {{track-progress}}
@@ -48,4 +49,5 @@
     </div>
   </div>
 </footer>
+{{/unless}}
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -38,9 +38,13 @@
   {{outlet}}
 </div>
 
-<footer>
-{{playback-control}}
-{{volume-control}}
-{{mute-control}}
-{{track-progress}}
+<footer class="footer">
+  <div class="container">
+    {{track-progress}}
+    <div class="playback-controls">
+      {{playback-control}}
+      {{volume-control}}
+    </div>
+  </div>
 </footer>
+

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -13,10 +13,21 @@
     </div>
     <div class="collapse navbar-collapse" id="navigation">
       <ul class="nav navbar-nav">
-        <li>{{#link-to "queue"}}Queue{{/link-to}}</li>
-        <li>{{#link-to "search"}}Search{{/link-to}}</li>
-        <li>{{#link-to "browse" "root"}}Browse{{/link-to}}</li>
-        <li>{{#link-to "playlists"}}Playlists{{/link-to}}</li>
+        {{#link-to "queue" tagName="li"}}
+          {{#link-to "queue"}}Queue{{/link-to}}
+        {{/link-to}}
+
+        {{#link-to "search" tagName="li"}}
+          {{#link-to "queue"}}Search{{/link-to}}
+        {{/link-to}}
+
+        {{#link-to "browse" "root" tagName="li"}}
+          {{#link-to "queue"}}Browse{{/link-to}}
+        {{/link-to}}
+
+        {{#link-to "playlists" tagName="li"}}
+          {{#link-to "queue"}}Playlists{{/link-to}}
+        {{/link-to}}
       </ul>
       {{playback-control}}
       {{volume-control}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -39,7 +39,7 @@
 </div>
 
 {{#unless bare}}
-<footer class="footer">
+<footer class="footer navbar-fixed-bottom">
   <div class="container">
     {{track-progress}}
     <div class="playback-controls">

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -42,6 +42,7 @@
   <div class="container">
     {{track-progress}}
     <div class="playback-controls">
+      <div></div>
       {{playback-control}}
       {{volume-control}}
     </div>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -29,10 +29,6 @@
           {{#link-to "queue"}}Playlists{{/link-to}}
         {{/link-to}}
       </ul>
-      {{playback-control}}
-      {{volume-control}}
-      {{mute-control}}
-      {{track-progress}}
     </div>
   </div>
 </nav>
@@ -41,3 +37,10 @@
 <div class="container">
   {{outlet}}
 </div>
+
+<footer>
+{{playback-control}}
+{{volume-control}}
+{{mute-control}}
+{{track-progress}}
+</footer>

--- a/app/templates/components/playback-control.hbs
+++ b/app/templates/components/playback-control.hbs
@@ -1,19 +1,19 @@
-<button class="btn btn-default navbar-btn" title="Previous" {{action "previous"}}>
+<button class="btn btn-default" title="Previous" {{action "previous"}}>
   <span class="glyphicon glyphicon-step-backward"></span>
 </button>
 
-<button title="Play" {{action "play"}} class="btn btn-default navbar-btn {{if isPlayVisible '' 'hidden'}}">
+<button title="Play" {{action "play"}} class="btn btn-default {{if isPlayVisible '' 'hidden'}}">
   <span class="glyphicon glyphicon-play"></span>
 </button>
 
-<button title="Pause" {{action "pause"}} class="btn btn-default navbar-btn {{if isPauseVisible '' 'hidden'}}">
+<button title="Pause" {{action "pause"}} class="btn btn-default {{if isPauseVisible '' 'hidden'}}">
   <span class="glyphicon glyphicon-pause"></span>
 </button>
 
-<button class="btn btn-default navbar-btn" title="Stop" {{action "stop"}}>
+<button class="btn btn-default" title="Stop" {{action "stop"}}>
   <span class="glyphicon glyphicon-stop"></span>
 </button>
 
-<button class="btn btn-default navbar-btn" title="Next" {{action "next"}}>
+<button class="btn btn-default" title="Next" {{action "next"}}>
   <span class="glyphicon glyphicon-step-forward"></span>
 </button>

--- a/app/templates/components/slider-control.hbs
+++ b/app/templates/components/slider-control.hbs
@@ -1,0 +1,5 @@
+<div>
+  <span class="active-segment" style="width: {{percentage}}%"></span>
+  <span class="handle" style="left: calc({{percentage}}% - 0.25em)"></span>
+</div>
+

--- a/app/templates/components/track-progress.hbs
+++ b/app/templates/components/track-progress.hbs
@@ -1,3 +1,4 @@
-<div class="form-group input-group">
-  {{input type="range" min="0" max="100" class="range-slider" title="Track progress" value=progress disabled=isDisabled}}
-</div>
+{{ slider-control percentage=percentage pre='pre' post='post' }}
+<div class="pull-left">{{ to-time currentTime }}</div>
+<div class="pull-right">{{ to-time duration }}</div>
+

--- a/app/templates/components/volume-control.hbs
+++ b/app/templates/components/volume-control.hbs
@@ -1,3 +1,4 @@
-<div>
-  {{input type="range" min="0" max="100" class="range-slider" title="Volume" value=volume}}
-</div>
+{{ mute-control }}
+{{ slider-control percentage=percentage post='post' }}
+{{!--<div>{{ percentage }}%</div>--}}
+

--- a/app/templates/components/volume-control.hbs
+++ b/app/templates/components/volume-control.hbs
@@ -1,3 +1,3 @@
-<div class="form-group input-group">
+<div>
   {{input type="range" min="0" max="100" class="range-slider" title="Volume" value=volume}}
 </div>


### PR DESCRIPTION
I moved the playback out of the header and into the footer and redesigned the
track sliders from scratch (the default ones don't have a shaded region).
Somethings which we may want to work on are:

TODO:
- Cleaning up dead code which is no longer used due to these changes. I
  cleaned up some of it but there might still be some left.
- ~~Move the step, play/pause and stop controls to the center and make the
  volume control slimmer horizontally.~~
- Move the stop button under a menu because its pretty useless.
- ~~Vendor Prefixing. It works in Chrome 44 but probably not anywhere else
  because of flexbox. Might want to add
  [ember-cli-autoprefixer](/kimroen/ember-cli-autoprefixer) to the pipeline.~~
  [Flexbox is well supported.](http://caniuse.com/#search=flexbox)
- ~~Some css animations on hover to indicate interaction on the sliders.~~
  [caffinatedmonkey/mopster](https://github.com/caffinatedmonkey/mopster/tree/animated-sliders)
- ~~Improve Slider Preformance~~
- A way to use keyboard buttons to interact with sliders and the ui in
  general.
- Simplify the UI and move things like single mode and consume mode behind a
  menu.
- ~~Display current track playing.~~
- ~~Album art
  http://stackoverflow.com/questions/11250434/what-free-api-has-the-largest-collection-of-albums-covers~~
  https://github.com/cowbell/mopster/pull/5

Please announce when you begin working on one of these, (if you want to work on
one) so we both aren't working on the same thing. I'm just keeping this here as
a personal todolist. This is ready to be merged. :) Cheers.

Here's a screenshot:
![screenshot 2015-08-11 at 7 47 13
pm](https://cloud.githubusercontent.com/assets/3277097/9213563/d6734952-4061-11e5-956c-29d013043997.png)
